### PR TITLE
fix: use triggering (latest) post content in push notifications

### DIFF
--- a/src/NotificationBuilder.php
+++ b/src/NotificationBuilder.php
@@ -81,7 +81,16 @@ class NotificationBuilder
         switch ($blueprint::getSubjectModel()) {
             case Discussion::class:
                 /** @var Discussion $subject */
-                $content = $this->getRelevantPostContent($subject);
+                // If the blueprint provides the post that triggered the notification
+                // (e.g. DiscussionRepliedBlueprint), use its content instead of
+                // falling back to the first post of the discussion.
+                $triggerPost = get_object_vars($blueprint)['post'] ?? null;
+
+                if ($triggerPost instanceof CommentPost) {
+                    $content = $triggerPost->formatContent();
+                } else {
+                    $content = $this->getRelevantPostContent($subject);
+                }
                 break;
             case Post::class:
                 /** @var Post $subject */


### PR DESCRIPTION
When a reply is posted to a discussion, push notifications showed the content of the original post instead of the new reply.

Fixes FriendsOfFlarum/pwa#4

**Changes proposed in this pull request:**
NotificationBuilder fell back to the discussion's first post because mostRelevantPost is not loaded in the notification context. Blueprints like DiscussionRepliedBlueprint already carry the triggering post as public $post, so use its content when available.

**Reviewers should focus on:**
Full disclosure. I have no Flarum dev experience and used AI to come up with the implementation. 

**Screenshot**

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

