### PR TITLE
feat: replace external notifications guide with local help page

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -50,7 +50,8 @@ return [
         ->js(__DIR__.'/js/dist/forum.js')
         ->jsDirectory(__DIR__.'/js/dist/forum')
         ->css(__DIR__.'/resources/less/forum.less')
-        ->content($metaClosure),
+        ->content($metaClosure)
+        ->route('/pwa-notifications-help', 'fof-pwa.notifications-help'),
 
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js')

--- a/js/src/forum/components/NotificationsHelpPage.tsx
+++ b/js/src/forum/components/NotificationsHelpPage.tsx
@@ -1,0 +1,54 @@
+import app from 'flarum/forum/app';
+import type { Vnode, Children } from 'mithril';
+import Page, { IPageAttrs } from 'flarum/common/components/Page';
+import PageStructure from 'flarum/forum/components/PageStructure';
+import extractText from 'flarum/common/utils/extractText';
+
+export default class NotificationsHelpPage extends Page {
+  oncreate(vnode: Vnode<IPageAttrs, this>) {
+    super.oncreate(vnode);
+    app.setTitle(extractText(app.translator.trans('fof-pwa.forum.notifications_help.browser_notifications_title')));
+    app.setTitleCount(0);
+  }
+
+  view(vnode: Vnode<IPageAttrs, this>): Children {
+    return (
+      <PageStructure
+        className="PWANotificationsHelpPage"
+        sidebar={() => /* @see https://github.com/flarum/framework/issues/4998 */ <div />}
+        hero={this.hero}
+      >
+        <section>
+          <h2>{app.translator.trans('fof-pwa.forum.notifications_help.chromium_title')}</h2>
+          <p>{app.translator.trans('fof-pwa.forum.notifications_help.chromium_instructions')}</p>
+        </section>
+
+        <section>
+          <h2>{app.translator.trans('fof-pwa.forum.notifications_help.firefox_title')}</h2>
+          <p>{app.translator.trans('fof-pwa.forum.notifications_help.firefox_instructions')}</p>
+        </section>
+
+        <section>
+          <h2>{app.translator.trans('fof-pwa.forum.notifications_help.safari_mac_title')}</h2>
+          <p>{app.translator.trans('fof-pwa.forum.notifications_help.safari_mac_instructions')}</p>
+        </section>
+
+        <section>
+          <h2>{app.translator.trans('fof-pwa.forum.notifications_help.safari_ios_title')}</h2>
+          <p>{app.translator.trans('fof-pwa.forum.notifications_help.safari_ios_instructions')}</p>
+        </section>
+      </PageStructure>
+    );
+  }
+
+  hero(): Children {
+    return (
+      <header className="Hero">
+        <div className="container">
+          <h1 className="Hero-title">{app.translator.trans('fof-pwa.forum.notifications_help.title')}</h1>
+          <p className="Hero-subtitle">{app.translator.trans('fof-pwa.forum.notifications_help.description')}</p>
+        </div>
+      </header>
+    );
+  }
+}

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -1,0 +1,3 @@
+import Extend from 'flarum/common/extenders';
+
+export default [new Extend.Routes().add('fof-pwa.notifications-help', '/pwa-notifications-help', () => import('./components/NotificationsHelpPage'))];

--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -6,6 +6,8 @@ import { pushConfigured, supportsWebPush } from './push/utils';
 import { syncPushSubscription } from './push/subscription';
 import { usingAppleWebview } from './native/appleWebView';
 
+export { default as extend } from './extend';
+
 app.initializers.add('fof-pwa', () => {
   addPushNotifications();
 

--- a/js/src/forum/push/addPushNotifications.tsx
+++ b/js/src/forum/push/addPushNotifications.tsx
@@ -5,6 +5,7 @@ import Alert from 'flarum/common/components/Alert';
 import Button from 'flarum/common/components/Button';
 import Icon from 'flarum/common/components/Icon';
 import ItemList from 'flarum/common/utils/ItemList';
+import LinkButton from 'flarum/common/components/LinkButton';
 import { usingAppleWebview } from '../native/appleWebView';
 import { getServiceWorkerRegistration } from '../registerServiceWorker';
 import { supportsWebPush, pushConfigured } from './utils';
@@ -91,14 +92,9 @@ export default function addPushNotifications(): void {
           dismissible={false}
           className="pwa-setting-alert"
           controls={[
-            <a
-              className="Button Button--link"
-              href="https://support.humblebundle.com/hc/en-us/articles/360008513933-Enabling-and-Disabling-Browser-Notifications-in-Various-Browsers"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <LinkButton href={app.route('fof-pwa.notifications-help')}>
               {app.translator.trans('fof-pwa.forum.settings.pwa_notifications.access_denied_button')}
-            </a>,
+            </LinkButton>,
           ]}
         >
           <Icon name="fas fa-exclamation-triangle" />

--- a/js/src/forum/push/showOptInAlert.tsx
+++ b/js/src/forum/push/showOptInAlert.tsx
@@ -3,6 +3,7 @@ import Button from 'flarum/common/components/Button';
 import { getServiceWorkerRegistration } from '../registerServiceWorker';
 import { syncPushSubscription } from './subscription';
 import { hasEnabledPushPreference, pushConfigured, supportsWebPush } from './utils';
+import LinkButton from 'flarum/common/components/LinkButton';
 
 const OPT_IN_DISMISSED_KEY = 'fof-pwa.notif-alert.dismissed';
 
@@ -42,7 +43,17 @@ export default function showOptInAlert() {
               }
 
               if (permission === 'denied') {
-                app.alerts.show({ type: 'error' }, app.translator.trans('fof-pwa.forum.alerts.optin_declined'));
+                app.alerts.show(
+                  {
+                    type: 'error',
+                    controls: [
+                      <LinkButton href={app.route('fof-pwa.notifications-help')}>
+                        {app.translator.trans('fof-pwa.forum.settings.pwa_notifications.access_denied_button')}
+                      </LinkButton>,
+                    ],
+                  },
+                  app.translator.trans('fof-pwa.forum.alerts.optin_declined')
+                );
                 return;
               }
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -3,3 +3,21 @@
     margin-right: 0.8em;
   }
 }
+
+.PWANotificationsHelpPage {
+  .Page-sidebar {
+    display: none;
+  }
+
+  .Page-container {
+    max-width: 500px;
+  }
+
+  .Page-content {
+    font-size: var(--post-font-size);
+
+    section {
+      margin-bottom: 2.3em;
+    }
+  }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -91,6 +91,22 @@ fof-pwa:
         access_denied_button: Learn How
         no_browser_support: This browser does not support push notifications for progressive web apps.
         no_browser_support_button: Learn More
+    notifications_help:
+      browser_notifications_title: "How to Enable Browser Notifications"
+      title: "Enable Push Notifications"
+      description: "If you previously blocked notifications, follow the instructions below for your device to re-enable them."
+
+      chromium_title: "Google Chrome, Microsoft Edge, & Android"
+      chromium_instructions: "Click the site information icon (padlock or tune icon) next to the web address in your browser. Select 'Site settings' (or 'Permissions'), find 'Notifications', and change the setting to 'Allow'."
+
+      firefox_title: "Mozilla Firefox"
+      firefox_instructions: "Click the padlock icon next to the web address. If you see 'Notifications' marked as 'Blocked', click the 'X' button next to it to remove the restriction. Refresh the page and allow notifications when prompted."
+
+      safari_mac_title: "Apple Safari (macOS)"
+      safari_mac_instructions: "Open the Safari menu at the top of your screen and select 'Settings' (or 'Preferences'). Click on the 'Websites' tab, select 'Notifications' on the left menu, find this forum in the list, and change the setting to 'Allow'."
+
+      safari_ios_title: "Apple iPhone & iPad (iOS/iPadOS)"
+      safari_ios_instructions: "Push notifications on iOS require the app to be installed. Tap the 'Share' icon in Safari and select 'Add to Home Screen'. Open the newly installed app. If notifications are blocked, open the iOS 'Settings' app, go to 'Notifications', select this web app from the list, and toggle 'Allow Notifications'."
 
   views:
     offline:


### PR DESCRIPTION
No longer sending users to an external page. This ensures the guide can be localized and the link won't expire.